### PR TITLE
Add git hook to prevent direct commits to main branch

### DIFF
--- a/bin/setup-git-hooks
+++ b/bin/setup-git-hooks
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Script to set up git hooks for the project
+# Run this script after cloning the repository
+
+echo "Setting up git hooks..."
+
+# Create pre-commit hook that prevents commits to main branch
+cat > .git/hooks/pre-commit << 'EOF'
+#!/usr/bin/env bash
+
+# Prevent commits directly on main branch
+branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+if [ "$branch" = "main" ]; then
+    echo "❌ Direct commits to main branch are not allowed!"
+    echo "Please create a feature branch first:"
+    echo "  git checkout -b feature/your-feature-name"
+    echo "  git add ."
+    echo "  git commit -m 'your commit message'"
+    exit 1
+fi
+
+# Run git secrets hook
+git secrets --pre_commit_hook -- "$@"
+EOF
+
+# Make the hook executable
+chmod +x .git/hooks/pre-commit
+
+echo "✅ Git hooks setup complete!"
+echo "Main branch protection is now active."

--- a/docs/git-hooks.md
+++ b/docs/git-hooks.md
@@ -1,0 +1,63 @@
+# Git Hooks Setup
+
+This project uses git hooks to enforce development workflow standards.
+
+## Main Branch Protection
+
+A pre-commit hook prevents direct commits to the main branch, requiring all changes to go through feature branches and pull requests.
+
+### Setup
+
+After cloning the repository, run:
+
+```bash
+bin/setup-git-hooks
+```
+
+### What it does
+
+- **Blocks commits to main**: Prevents accidental direct commits to the main branch
+- **Provides helpful guidance**: Shows clear error message with instructions
+- **Preserves git-secrets**: Maintains existing security scanning functionality
+
+### Example
+
+```bash
+# This will be blocked:
+git checkout main
+git commit -m "some change"
+# ❌ Direct commits to main branch are not allowed!
+
+# This works:
+git checkout -b feature/my-feature
+git commit -m "some change"
+# ✅ Commit successful
+```
+
+### Bypass (Emergency Only)
+
+If you absolutely must commit directly to main (emergency hotfix):
+
+```bash
+git commit --no-verify -m "emergency fix"
+```
+
+**Note**: This should only be used in genuine emergencies and requires careful review.
+
+## Other Hooks
+
+- **git-secrets**: Scans for AWS credentials and other secrets before commits
+- **prepare-commit-msg**: Adds context to commit messages
+
+## Development Workflow
+
+1. Always create feature branches: `git checkout -b feature/your-feature`
+2. Make commits on feature branches
+3. Create pull requests for code review
+4. Merge to main via PR only
+
+This ensures:
+- All changes are reviewed
+- Main branch history is clean
+- CI/CD runs on all changes
+- Rollback is easier if needed


### PR DESCRIPTION
## Summary
- Add setup script for git hooks that prevents direct commits to main branch
- Comprehensive documentation for git hooks and development workflow
- Preserves existing git-secrets functionality

## Problem
Currently developers can accidentally commit directly to the main branch, bypassing the PR review process and potentially introducing issues.

## Solution
Implemented a pre-commit git hook that:
- Blocks any direct commits to main branch
- Provides clear error message with instructions
- Guides developers to create feature branches
- Maintains existing git-secrets security scanning

## Files Added
- `bin/setup-git-hooks` - Script to install git hooks after cloning
- `docs/git-hooks.md` - Documentation for git hooks and workflow

## Test Plan
- [x] Hook successfully blocks commits to main branch
- [x] Hook allows commits on feature branches
- [x] Clear error messaging and guidance
- [x] Preserves git-secrets functionality
- [x] Setup script works correctly

## Usage
After cloning the repository, run:
```bash
bin/setup-git-hooks
```

## Benefits
- Prevents accidental commits to main
- Enforces proper PR workflow
- Maintains clean main branch history
- Easier rollbacks when needed
- Better code review coverage

🤖 Generated with [Claude Code](https://claude.ai/code)