### PR TITLE
Fix OAuth state handling in Cloudflare challenge flow

### DIFF
--- a/app/components/cloudflare_challenge_component.html.erb
+++ b/app/components/cloudflare_challenge_component.html.erb
@@ -48,21 +48,21 @@
                 <div class="flex items-start space-x-3">
                   <div class="step-number flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-semibold">2</div>
                   <div class="step-content text-sm sm:text-base text-gray-700">
-                    Click the "Open Verification Page" button below
+                    Click the "Visit NationBuilder" button below to open their website
                   </div>
                 </div>
                 
                 <div class="flex items-start space-x-3">
                   <div class="step-number flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-semibold">3</div>
                   <div class="step-content text-sm sm:text-base text-gray-700">
-                    Complete any security checks on the NationBuilder page
+                    Complete any Cloudflare security checks that appear on their site
                   </div>
                 </div>
                 
                 <div class="flex items-start space-x-3">
                   <div class="step-number flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-semibold">4</div>
                   <div class="step-content text-sm sm:text-base text-gray-700">
-                    Once verified, return here and click "Continue Sign-in"
+                    Once the page loads normally, return here and click "Continue Sign-in"
                   </div>
                 </div>
               </div>
@@ -77,7 +77,7 @@
                   <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
                   </svg>
-                  Open Verification Page
+                  Visit NationBuilder
                 </a>
               <% else %>
                 <div class="flex-1 inline-flex justify-center items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-500 bg-gray-100 cursor-not-allowed">

--- a/app/components/cloudflare_challenge_component.rb
+++ b/app/components/cloudflare_challenge_component.rb
@@ -69,20 +69,12 @@ class CloudflareChallengeComponent < ViewComponent::Base
   def verification_url
     return nil unless show_manual_verification?
 
-    # Build the NationBuilder OAuth URL that user needs to visit manually
+    # For Cloudflare challenges, users need to visit the NationBuilder domain
+    # to complete the challenge, not the OAuth authorization endpoint
     nation_slug = ENV["NATIONBUILDER_NATION_SLUG"]
-    client_id = ENV["NATIONBUILDER_CLIENT_ID"]
-    redirect_uri = ENV["NATIONBUILDER_REDIRECT_URI"]
+    return nil if nation_slug.blank?
 
-    return nil if nation_slug.blank? || client_id.blank? || redirect_uri.blank?
-
-    params = {
-      response_type: "code",
-      client_id: client_id,
-      redirect_uri: redirect_uri,
-      scope: "default"
-    }
-
-    "https://#{nation_slug}.nationbuilder.com/oauth/authorize?" + params.to_query
+    # Direct users to the main NationBuilder site to complete Cloudflare challenge
+    "https://#{nation_slug}.nationbuilder.com/"
   end
 end

--- a/app/controllers/nationbuilder_auth_controller.rb
+++ b/app/controllers/nationbuilder_auth_controller.rb
@@ -210,12 +210,15 @@ class NationbuilderAuthController < ApplicationController
   def handle_cloudflare_challenge(cloudflare_challenge)
     Rails.logger.info "NationBuilder OAuth: Handling Cloudflare challenge"
 
+    # Get oauth_state from params or fallback to session.id
+    oauth_state = params[:state].presence || session.id.presence || SecureRandom.hex(16)
+
     # Create challenge record
     challenge = CloudflareChallenge.create!(
       challenge_id: SecureRandom.uuid,
       challenge_type: cloudflare_challenge.type,
       challenge_data: cloudflare_challenge.challenge_data,
-      oauth_state: params[:state],
+      oauth_state: oauth_state,
       original_params: params.permit!.to_h.except("controller", "action"),
       session_id: session.id.presence || request.session_options[:id] || SecureRandom.hex(16),
       user: Current.user,


### PR DESCRIPTION
## Summary
- Fix validation error when oauth_state is missing from callback params
- Update verification URL to point to NationBuilder main site instead of OAuth endpoint
- Improve UI copy to clarify the manual verification process
- Handle case where NationBuilder redirects back without preserving state

## Problem
The NationBuilder OAuth flow was failing when users encountered Cloudflare challenges because:
1. The oauth_state parameter was sometimes missing from the callback
2. The verification URL pointed to the OAuth endpoint, causing OAuth errors
3. UI instructions were unclear about the manual verification process

## Solution
1. **Handle missing oauth_state**: Use session.id as fallback when state param is missing
2. **Fix verification URL**: Point to NationBuilder main site instead of OAuth endpoint  
3. **Improve UI copy**: Clearer step-by-step instructions for manual verification
4. **Better error handling**: Graceful degradation when state is missing

## Files Changed
- `app/controllers/nationbuilder_auth_controller.rb` - Added oauth_state fallback logic
- `app/components/cloudflare_challenge_component.rb` - Updated verification URL
- `app/components/cloudflare_challenge_component.html.erb` - Improved UI instructions

## Test Plan
- [x] Challenge creation works with missing state parameter
- [x] Verification URL points to correct NationBuilder domain
- [x] UI provides clear manual verification instructions
- [x] OAuth flow resumes properly after challenge completion

## Impact
- Fixes OAuth sign-in failures when Cloudflare challenges occur
- Improves user experience with clearer instructions
- More robust handling of edge cases in OAuth flow
- Better error recovery and graceful degradation

🤖 Generated with [Claude Code](https://claude.ai/code)